### PR TITLE
fixed failing tests

### DIFF
--- a/packages/diagrams-demo-gallery/tests-e2e/helpers/E2ELink.ts
+++ b/packages/diagrams-demo-gallery/tests-e2e/helpers/E2ELink.ts
@@ -6,10 +6,10 @@ export class E2ELink extends E2EBase {
 	async select(): Promise<any> {
 		const point = await page.evaluate((id) => {
 			const path = document.querySelector(id) as SVGPathElement;
-			const point = path.getPointAtLength(path.getTotalLength() / 2);
+			const rect = path.getClientRects().item(0);
 			return {
-				x: point.x,
-				y: point.y
+				x: rect.x + rect.width / 2,
+				y: rect.y
 			};
 		}, this.selector());
 		await page.keyboard.down('Shift');

--- a/packages/react-diagrams-routing/tests/PathFinding.test.tsx
+++ b/packages/react-diagrams-routing/tests/PathFinding.test.tsx
@@ -1,6 +1,6 @@
 import PathFinding from '../src/engine/PathFinding';
 
-describe('calculating start and end points', () => {
+describe('calculating start and end points', function() {
 	beforeEach(() => {
 		this.pathFinding = new PathFinding(null);
 	});


### PR DESCRIPTION
iframe.html has body padding set to 1rem by default, so using getClientRects() instead of svg getPointAtLength()